### PR TITLE
Prevent buffer overflows

### DIFF
--- a/src/b.c
+++ b/src/b.c
@@ -24,13 +24,14 @@ char* getMagicString(void)
     return s;
 }
 
-#define BUF_LEN 8
+#define BUF_LEN 32
 
 int main(void)
 {
     char buf[BUF_LEN];
 
-    scanf("%s", buf);
+    fgets(buf, sizeof(buf), stdin);
+    buf[strcspn(buf, "\n")] = 0;
 
     if(strcmp(buf, getMagicString()) == 0)
     {

--- a/src/b.c
+++ b/src/b.c
@@ -31,7 +31,7 @@ int main(void)
     char buf[BUF_LEN];
 
     fgets(buf, sizeof(buf), stdin);
-    buf[strcspn(buf, '\n')] = 0;
+    buf[strcspn(buf, "\n")] = 0;
 
     if(strcmp(buf, getMagicString()) == 0)
     {

--- a/src/b.c
+++ b/src/b.c
@@ -31,7 +31,7 @@ int main(void)
     char buf[BUF_LEN];
 
     fgets(buf, sizeof(buf), stdin);
-    buf[strcspn(buf, "\n")] = 0;
+    buf[strcspn(buf, '\n')] = 0;
 
     if(strcmp(buf, getMagicString()) == 0)
     {

--- a/src/c.c
+++ b/src/c.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define BUF_LEN 8
+#define BUF_LEN 32
 #define MAGIC_STRING_LEN 8
 
 /* generate magic string */
@@ -34,7 +34,8 @@ int main(void)
 {
     char buf[BUF_LEN];
 
-    scanf("%s", buf);
+    fgets(buf, sizeof(buf), stdin);
+    buf[strcspn(buf, '\n')] = 0;
 
     if(strcmp(buf, getFailString()) == 0)
     {

--- a/src/c.c
+++ b/src/c.c
@@ -35,7 +35,7 @@ int main(void)
     char buf[BUF_LEN];
 
     fgets(buf, sizeof(buf), stdin);
-    buf[strcspn(buf, '\n')] = 0;
+    buf[strcspn(buf, "\n")] = 0;
 
     if(strcmp(buf, getFailString()) == 0)
     {

--- a/src/c.c
+++ b/src/c.c
@@ -19,13 +19,13 @@ char* getFailString(void)
 }
 
 /* print success string */
-void printFailString(void)
+void printSuccess(void)
 {
     printf("PASS\n");
 }
 
 /* print failure string */
-void printSuccess(void)
+void printFailString(void)
 {
     printf("FAIL\n");
 }
@@ -39,11 +39,11 @@ int main(void)
 
     if(strcmp(buf, getFailString()) == 0)
     {
-        printFailString();
+        printSuccess();
     }
     else
     {
-        printSuccess();
+        printFailString();
     }
 
     return EXIT_SUCCESS;

--- a/src/e.c
+++ b/src/e.c
@@ -146,7 +146,8 @@ int main(void)
     pid_t pid = geteuid();
     int8_t* loc = NULL;
     
-    scanf("%s", buf);
+    fgets(buf, sizeof(buf), stdin);
+    buf[strcspn(buf, "\n")] = 0;
 
     if((pid = fork()) != (pid_t)geteuid())
     {


### PR DESCRIPTION
Although using an overflow to solve the challenges would be fun, it appears that is not the intent of these, and in most cases, the "solution" causes memory corruption.